### PR TITLE
Update eisaR.Rmd

### DIFF
--- a/vignettes/eisaR.Rmd
+++ b/vignettes/eisaR.Rmd
@@ -111,9 +111,6 @@ We next align the reads to a mini-genome (fasta file `extdata/hg19sub.fa`) using
 `qAlign`:  
 
 ```{r align}
-sampleFile <- "extdata/samples_chip_single.txt"
-genomeFile <- "extdata/hg19sub.fa"
-
 proj <- qAlign("extdata/samples_rna_single.txt", "extdata/hg19sub.fa",
                aligner = "Rhisat2", splicedAlignment = TRUE)
 alignmentStats(proj)

--- a/vignettes/eisaR.Rmd
+++ b/vignettes/eisaR.Rmd
@@ -257,7 +257,7 @@ plot(res1$contrasts[ids,"Dex.Din"], res2$contrasts[ids,"Dex.Din"], pch = "*",
 ## On the estimation of interactions in a split-plot design experiment
 The calculation of the significance of interactions (here whether the fold-changes
 differ between exonic or intronic data) is well defined for experimental designs
-were all samples are independent from one another. Within EISA, this is not the
+where all samples are independent from one another. Within EISA, this is not the
 case (each sample yields two data points, on for exons and one for introns). That
 results in a dependency between datapoints: If a sample is affected by a problem
 in the experiment, it might at the same time give rise to outliers in both exonic


### PR DESCRIPTION
Catching a typo

Plus a couple of notes:
- `res2` and `res4` are de facto identical - maybe you can save some time when computing them
- no need to define `sampleFile` and `genomeFile` -> not used (`sampleFile` should also be `samples_rna` instead of `chip`?)

Unrelated to the PR:
Jan (colleague of mine) is working on using `featureCounts` as alternative to `QuasR` - happy to drop a PR on that by giving a forking point to the workflow