### PR TITLE
Fix GHA fail on macOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -99,12 +99,6 @@ jobs:
       - name: Build, Install, Check
         uses: grimbough/bioc-actions/build-install-check@v1
 
-      - name: BiocCheck
-        run: |
-          BiocManager::install("BiocCheck")
-          BiocCheck::BiocCheck(".")
-        shell: Rscript {0}
-        
       - name: Run BiocCheck
         uses: grimbough/bioc-actions/run-BiocCheck@v1
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -96,6 +96,55 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
+      - name: Build Rhisat2 index (1)
+        run: |
+            library(QuasR)
+            library(Rhisat2)
+            file.copy(system.file(package = "QuasR", "extdata"), ".", recursive = TRUE)
+            Rhisat2::hisat2_build("extdata/hg19sub.fa", outdir = tempfile("index1_"))
+        shell: Rscript {0}
+
+      - name: Build Rhisat2 index (2)
+        run: |
+            ret <- system2(file.path(system.file(package = "Rhisat2"), "hisat2-build"),
+                   c(shQuote("extdata/hg19sub.fa"), 
+                   shQuote(tempfile("index2_"))), 
+                   stdout = TRUE, stderr = TRUE)
+            ret
+            grepl("^Total time for call to driver", ret[length(ret)])
+
+      - name: Build Rhisat2 index (3)
+        run: |
+            buildIndex_Rhisat2_mod <- function(seqFile,indexPath) {
+                indexFullPath <- file.path(indexPath, "hisat2Index")
+                ret <- system2(file.path(system.file(package = "Rhisat2"), "hisat2-build"),
+                   c(shQuote(seqFile), shQuote(indexFullPath)), 
+                   stdout = TRUE, stderr = TRUE)
+                if (!(grepl("^Total time for call to driver", ret[length(ret)]))) {
+                    print(ret)
+                    ret <- 1
+                } else {
+                    ret <- 0
+                }
+                return(ret)
+            }
+            buildIndex_Rhisat2_mod("extdata/hg19sub.fa", tempfile("index3_"))
+
+      - name: Build Rhisat2 index (4)
+        run: |
+            library(QuasR)
+            QuasR:::buildIndex_Rhisat2("extdata/hg19sub.fa", tempfile("index4_"))
+        shell: Rscript {0}
+
+      - name: Align to Rhisat2 index
+        run: |
+            library(QuasR)
+            sampleFile <- "extdata/samples_rna_single.txt"
+            proj <- qAlign(sampleFile = sampleFile, 
+                           genome = "extdata/hg19sub.fa",
+                           aligner = "Rhisat2", splicedAlignment = TRUE)
+        shell: Rscript {0}
+
       - name: Build, Install, Check
         uses: grimbough/bioc-actions/build-install-check@v1
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -96,57 +96,6 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - name: Build Rhisat2 index (1)
-        run: |
-            library(QuasR)
-            library(Rhisat2)
-            file.copy(system.file(package = "QuasR", "extdata"), ".", recursive = TRUE)
-            Rhisat2::hisat2_build("extdata/hg19sub.fa", outdir = tempfile("index1_"))
-        shell: Rscript {0}
-
-      - name: Build Rhisat2 index (2)
-        run: |
-            ret = system2(file.path(system.file(package = "Rhisat2"), "hisat2-build"),
-                          c(shQuote("extdata/hg19sub.fa"), 
-                            shQuote(tempfile("index2_"))), 
-                          stdout = TRUE, stderr = TRUE)
-            ret
-            grepl("^Total time for call to driver", ret[length(ret)])
-        shell: Rscript {0}
-
-      - name: Build Rhisat2 index (3)
-        run: |
-            buildIndex_Rhisat2_mod <- function(seqFile,indexPath) {
-                indexFullPath <- file.path(indexPath, "hisat2Index")
-                ret <- system2(file.path(system.file(package = "Rhisat2"), "hisat2-build"),
-                   c(shQuote(seqFile), shQuote(indexFullPath)), 
-                   stdout = TRUE, stderr = TRUE)
-                if (!(grepl("^Total time for call to driver", ret[length(ret)]))) {
-                    print(ret)
-                    ret <- 1
-                } else {
-                    ret <- 0
-                }
-                return(ret)
-            }
-            buildIndex_Rhisat2_mod("extdata/hg19sub.fa", tempfile("index3_"))
-        shell: Rscript {0}
-
-      - name: Build Rhisat2 index (4)
-        run: |
-            library(QuasR)
-            QuasR:::buildIndex_Rhisat2("extdata/hg19sub.fa", tempfile("index4_"))
-        shell: Rscript {0}
-
-      - name: Align to Rhisat2 index
-        run: |
-            library(QuasR)
-            sampleFile <- "extdata/samples_rna_single.txt"
-            proj <- qAlign(sampleFile = sampleFile, 
-                           genome = "extdata/hg19sub.fa",
-                           aligner = "Rhisat2", splicedAlignment = TRUE)
-        shell: Rscript {0}
-
       - name: Build, Install, Check
         uses: grimbough/bioc-actions/build-install-check@v1
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         config:
           - { os: windows-latest, bioc: 'devel', deploy: 'no'}
-          - { os: macOS-latest, bioc: 'devel', deploy: 'yes', curlConfigPath: '/usr/bin/'}
+          - { os: macOS-12, bioc: 'devel', deploy: 'yes', curlConfigPath: '/usr/bin/'}
           # - { os: ubuntu-16.04, r: 'devel', bioc: 'devel', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest", deploy = 'no'}
           # - { os: ubuntu-latest, r: 'devel', image: 'bioconductor/bioconductor_docker:devel', deploy: 'no'}
 
@@ -169,7 +169,7 @@ jobs:
           path: check
 
       - name: Test coverage
-        if: matrix.config.os == 'macOS-latest' && matrix.config.bioc == 'devel'
+        if: matrix.config.os == 'macOS-12' && matrix.config.bioc == 'devel'
         run: |
           install.packages("covr")
           covr::codecov(token = "${{secrets.CODECOV_TOKEN}}")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -99,6 +99,12 @@ jobs:
       - name: Build, Install, Check
         uses: grimbough/bioc-actions/build-install-check@v1
 
+      - name: BiocCheck
+        run: |
+          BiocManager::install("BiocCheck")
+          BiocCheck::BiocCheck(".")
+        shell: Rscript {0}
+        
       - name: Run BiocCheck
         uses: grimbough/bioc-actions/run-BiocCheck@v1
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -106,12 +106,13 @@ jobs:
 
       - name: Build Rhisat2 index (2)
         run: |
-            ret <- system2(file.path(system.file(package = "Rhisat2"), "hisat2-build"),
-                   c(shQuote("extdata/hg19sub.fa"), 
-                   shQuote(tempfile("index2_"))), 
-                   stdout = TRUE, stderr = TRUE)
+            ret = system2(file.path(system.file(package = "Rhisat2"), "hisat2-build"),
+                          c(shQuote("extdata/hg19sub.fa"), 
+                            shQuote(tempfile("index2_"))), 
+                          stdout = TRUE, stderr = TRUE)
             ret
             grepl("^Total time for call to driver", ret[length(ret)])
+        shell: Rscript {0}
 
       - name: Build Rhisat2 index (3)
         run: |
@@ -129,6 +130,7 @@ jobs:
                 return(ret)
             }
             buildIndex_Rhisat2_mod("extdata/hg19sub.fa", tempfile("index3_"))
+        shell: Rscript {0}
 
       - name: Build Rhisat2 index (4)
         run: |


### PR DESCRIPTION
I added some extra steps to the GHA to try to diagnose the vignette building (`Rhisat2` index generation) error on macOS. I got the following error: 

```
sh: line 1: 15863 Abort trap: 6           '/Users/runner/work/_temp/Library/Rhisat2/hisat2-build' 'extdata/hg19sub.fa' '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//RtmpLXCPi6/index3_3deb4b3e29b6/hisat2Index' 2>&1
[1] "dyld: Symbol not found: __ZTTNSt3__114basic_ifstreamIcNS_11char_traitsIcEEEE"                                
Warning message:
[2] "  Referenced from: /Users/runner/work/_temp/Library/Rhisat2/hisat2-build (which was built for Mac OS X 12.0)"
In system2(file.path(system.file(package = "Rhisat2"), "hisat2-build"),  :
[3] "  Expected in: /usr/lib/libc++.1.dylib"                                                                      
  running command ''/Users/runner/work/_temp/Library/Rhisat2/hisat2-build' 'extdata/hg19sub.fa' '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//RtmpLXCPi6/index3_3deb4b3e29b6/hisat2Index' 2>&1' had status 134
[4] " in /Users/runner/work/_temp/Library/Rhisat2/hisat2-build"                                                   
attr(,"status")
[1] 134 
```

The `macOS-latest` runner is currently on macOS 11.6.8. Running instead on `macOS-12` seems to solve the issue. 